### PR TITLE
Add the bootnode for the hedgeware chain into the chainspec directly

### DIFF
--- a/src/chain_spec.rs
+++ b/src/chain_spec.rs
@@ -85,7 +85,11 @@ pub fn hedgeware(id: ParaId) -> ChainSpec {
 				true,
 			)
 		},
-		Vec::new(),
+		vec![
+      "/ip4/143.198.160.202/tcp/30333/p2p/12D3KooWKnA5vkSiy96GwPVC2fMEiooP9ptqheQiNEYa8YrudHVv"
+      .parse()
+      .unwrap()
+    ],
 		None,
 		None,
 		properties,


### PR DESCRIPTION
to better accomodate for build scripts